### PR TITLE
➕ Return x-pack modules to add missing flattened dependency

### DIFF
--- a/packer/install.sh
+++ b/packer/install.sh
@@ -18,5 +18,3 @@ LimitMEMLOCK=infinity" | sudo tee /etc/systemd/system/elasticsearch.service.d/ov
 sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install -b discovery-gce
 sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install -b repository-gcs
 sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install -b analysis-icu
-
-sudo rm -Rf /usr/share/elasticsearch/modules/x-pack*


### PR DESCRIPTION
`/usr/share/elasticsearch/modules/x-pack*` was being removed from the image by install script for some reason which caused that Elasticsearch could not start after upgrade to 7.4.2:

```
Missing plugin x-pack-core, dependency of [flattened]
```

It works correctly after returning x-pack modules to the image.